### PR TITLE
Py3compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ python:
 env:
  - TOX_ENV=flake8
  - TOX_ENV=pydocstyle
- - TOX_ENV=py27
- - TOX_ENV=py3
 install:
  - pip install tox-travis
 script:
+ - tox
  - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 sudo: false
 language: python
-python: 2.7
+python:
+ - "2.7"
+ - "3.4"
 env:
  - TOX_ENV=flake8
  - TOX_ENV=pydocstyle
  - TOX_ENV=py27
+ - TOX_ENV=py3
 install:
  - pip install tox-travis
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ python:
 env:
  - TOX_ENV=flake8
  - TOX_ENV=pydocstyle
+ - TOX_ENV=py27
+ - TOX_ENV=py3
 install:
  - pip install tox-travis
 script:
- - tox
  - tox -e $TOX_ENV

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+future
 git+https://github.com/wikimedia/pywikibot-core.git
 MySQL-python
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 future
-git+https://github.com/wikimedia/pywikibot-core.git
-MySQL-python
+mysqlclient
 requests
+git+https://github.com/wikimedia/pywikibot-core.git

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from setuptools import setup
-version = '0.1.1'
+version = '0.2.0'
 repo = 'wikidata-stuff'
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from setuptools import setup
 version = '0.1.1'

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from setuptools import setup
 version = '0.1.1'
 repo = 'wikidata-stuff'
@@ -5,17 +6,22 @@ repo = 'wikidata-stuff'
 setup(
     name='wikidataStuff',
     packages=['wikidataStuff'],
-    install_requires=['pywikibot==3.0-dev', 'requests', 'MySQL-python'],
+    install_requires=[
+        'pywikibot==3.0-dev',
+        'requests',
+        'future',
+        'MySQL-python'
+    ],
     dependency_links=['git+https://github.com/wikimedia/pywikibot-core.git#egg=pywikibot-3.0-dev'],
     version=version,
     description='Framework for mass-importing statements to Wikidata and/or for adding sources to existing statements.',
-    author='Andre Costa',
+    author='André Costa',
     author_email='',
     url='https://github.com/lokal-profil/' + repo,
     download_url='https://github.com/lokal-profil/' + repo + '/tarball/' + version,
     keywords=['Wikidata', 'Wikimedia', 'pywikibot', 'API'],
     classifiers=[
         'Programming Language :: Python :: 2.7'
-        # no py3 support due to MySQL-python
+        'Programming Language :: Python :: 3.4'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         'pywikibot==3.0-dev',
         'requests',
         'future',
-        'MySQL-python'
+        'mysqlclient'
     ],
     dependency_links=['git+https://github.com/wikimedia/pywikibot-core.git#egg=pywikibot-3.0-dev'],
     version=version,

--- a/tests/data/update_data.py
+++ b/tests/data/update_data.py
@@ -1,14 +1,15 @@
 #!/usr/bin/python
 # -*- coding: utf-8  -*-
 """Import and update test_data."""
-
+from __future__ import unicode_literals
+from builtins import open
 from shutil import copyfile
 import requests
 import json
-import codecs
 
 # load new
-url = 'https://test.wikidata.org/w/api.php?action=wbgetentities&format=json&ids=Q27399'
+api_endpoint = 'https://test.wikidata.org/w/api.php?'
+url = '%saction=wbgetentities&format=json&ids=Q27399' % api_endpoint
 r = requests.get(url)
 loaded_data = json.loads(r.text)
 
@@ -17,5 +18,5 @@ filename = 'Q27399.json'
 copyfile(filename, '%s.backup' % filename)
 
 # output new
-with codecs.open(filename, 'w', 'utf-8') as f:
+with open(filename, 'w', encoding='utf-8') as f:
     f.write(json.dumps(loaded_data, indent=4, ensure_ascii=False))

--- a/tests/test_WikidataStuff.py
+++ b/tests/test_WikidataStuff.py
@@ -17,20 +17,20 @@ class TestListify(unittest.TestCase):
     """Test listify()."""
 
     def test_listify_none(self):
-        self.assertEquals(WD.listify(None), None)
+        self.assertEqual(WD.listify(None), None)
 
     def test_listify_empty_list(self):
-        self.assertEquals(WD.listify([]), [])
+        self.assertEqual(WD.listify([]), [])
 
     def test_listify_list(self):
         input_value = ['a', 'c']
         expected = ['a', 'c']
-        self.assertEquals(WD.listify(input_value), expected)
+        self.assertEqual(WD.listify(input_value), expected)
 
     def test_listify_string(self):
         input_value = 'a string'
         expected = ['a string']
-        self.assertEquals(WD.listify(input_value), expected)
+        self.assertEqual(WD.listify(input_value), expected)
 
 
 class BaseTest(unittest.TestCase):
@@ -153,14 +153,14 @@ class TestHasClaim(BaseTest):
     def test_has_claim_prop_not_present(self):
         prop = 'P0'
         itis = 'A string'
-        self.assertEquals(
+        self.assertEqual(
             self.wd_stuff.has_claim(prop, itis, self.wd_page),
             [])
 
     def test_has_claim_prop_but_not_value(self):
         prop = 'P174'
         itis = 'An unknown string'
-        self.assertEquals(
+        self.assertEqual(
             self.wd_stuff.has_claim(prop, itis, self.wd_page),
             [])
 
@@ -170,8 +170,8 @@ class TestHasClaim(BaseTest):
         expected = 'Q27399$3f62d521-4efe-e8de-8f2d-0d8a10e024cf'
 
         hits = self.wd_stuff.has_claim(prop, itis, self.wd_page)
-        self.assertEquals(len(hits), 1)
-        self.assertEquals(
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(
             hits[0].toJSON()['id'],
             expected)
 
@@ -181,8 +181,8 @@ class TestHasClaim(BaseTest):
         expected = 'Q27399$ef9f73ce-4cd5-13e5-a0bf-4ad835d8f9c3'
 
         hits = self.wd_stuff.has_claim(prop, itis, self.wd_page)
-        self.assertEquals(len(hits), 1)
-        self.assertEquals(
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(
             hits[0].toJSON()['id'],
             expected)
 
@@ -192,8 +192,8 @@ class TestHasClaim(BaseTest):
         expected = 'Q27399$58a0a8bc-46e4-3dc6-16fe-e7c364103c9b'
 
         hits = self.wd_stuff.has_claim(prop, itis, self.wd_page)
-        self.assertEquals(len(hits), 1)
-        self.assertEquals(
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(
             hits[0].toJSON()['id'],
             expected)
 
@@ -213,8 +213,8 @@ class TestHasClaim(BaseTest):
         expected = 'Q27399$50b7cccb-4e9d-6f5d-d9c9-6b85d771c2d4'
 
         hits = self.wd_stuff.has_claim(prop, itis, self.wd_page)
-        self.assertEquals(len(hits), 1)
-        self.assertEquals(
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(
             hits[0].toJSON()['id'],
             expected)
 
@@ -225,11 +225,11 @@ class TestHasClaim(BaseTest):
         expected_2 = 'Q27399$a9b83de1-49d7-d033-939d-f430a232ffd0'
 
         hits = self.wd_stuff.has_claim(prop, itis, self.wd_page)
-        self.assertEquals(len(hits), 2)
-        self.assertEquals(
+        self.assertEqual(len(hits), 2)
+        self.assertEqual(
             hits[0].toJSON()['id'],
             expected_1)
-        self.assertEquals(
+        self.assertEqual(
             hits[1].toJSON()['id'],
             expected_2)
 
@@ -323,7 +323,7 @@ class TestHasAllQualifiers(BaseTest):
 
     def test_has_all_qualifiers_empty(self):
         expected = (True, True)
-        self.assertEquals(
+        self.assertEqual(
             self.wd_stuff.has_all_qualifiers(self.quals, self.claim_no_qual),
             expected)
 
@@ -331,7 +331,7 @@ class TestHasAllQualifiers(BaseTest):
         self.quals.append(self.qual_1)
         self.quals.append(self.qual_2)
         expected = (True, True)
-        self.assertEquals(
+        self.assertEqual(
             self.wd_stuff.has_all_qualifiers(self.quals, self.claim),
             expected)
 
@@ -340,14 +340,14 @@ class TestHasAllQualifiers(BaseTest):
         self.quals.append(self.qual_2)
         self.quals.append(self.unmatched)
         expected = (False, False)
-        self.assertEquals(
+        self.assertEqual(
             self.wd_stuff.has_all_qualifiers(self.quals, self.claim),
             expected)
 
     def test_has_all_qualifiers_has_all_plus_one(self):
         self.quals.append(self.qual_1)
         expected = (False, True)
-        self.assertEquals(
+        self.assertEqual(
             self.wd_stuff.has_all_qualifiers(self.quals, self.claim),
             expected)
 
@@ -498,7 +498,7 @@ class TestAddQualifier(BaseTest):
     def test_add_qualifier_empty_qual(self):
         with self.assertRaises(pywikibot.Error) as e:
             self.wd_stuff.addQualifier(item=None, claim=None, qual=None)
-        self.assertEquals(
+        self.assertEqual(
             str(e.exception),
             'Cannot call addQualifier() without a qualifier.')
         self.mock_has_qualifier.assert_not_called()
@@ -606,7 +606,7 @@ class TestAddNewClaim(BaseTest):
         self.mock_add_reference.assert_called_once()
 
         # ensure the right claim was sourced
-        self.assertEquals(
+        self.assertEqual(
             self.mock_add_reference.call_args[0][1].toJSON()['id'],
             expected_claim)
 
@@ -616,7 +616,7 @@ class TestAddNewClaim(BaseTest):
         self.wd_stuff.addNewClaim(self.prop, statement, self.wd_page, self.ref)
 
         self.mock_add_claim.assert_called_once()
-        self.assertEquals(self.mock_add_qualifier.call_count, 2)
+        self.assertEqual(self.mock_add_qualifier.call_count, 2)
         self.mock_add_reference.assert_called_once()
 
     def test_add_new_claim_old_property_new_value_with_quals(self):
@@ -626,7 +626,7 @@ class TestAddNewClaim(BaseTest):
         self.wd_stuff.addNewClaim(self.prop, statement, self.wd_page, self.ref)
 
         self.mock_add_claim.assert_called_once()
-        self.assertEquals(self.mock_add_qualifier.call_count, 2)
+        self.assertEqual(self.mock_add_qualifier.call_count, 2)
         self.mock_add_reference.assert_called_once()
 
     def test_add_new_claim_old_property_old_value_without_quals(self):
@@ -638,9 +638,9 @@ class TestAddNewClaim(BaseTest):
         self.wd_stuff.addNewClaim(self.prop, statement, self.wd_page, self.ref)
 
         self.mock_add_claim.assert_not_called()
-        self.assertEquals(self.mock_add_qualifier.call_count, 2)
+        self.assertEqual(self.mock_add_qualifier.call_count, 2)
         self.mock_add_reference.assert_called_once()
-        self.assertEquals(
+        self.assertEqual(
             self.mock_add_reference.call_args[0][1].toJSON()['id'],
             expected_claim)
 
@@ -652,7 +652,7 @@ class TestAddNewClaim(BaseTest):
         self.wd_stuff.addNewClaim(self.prop, statement, self.wd_page, self.ref)
 
         self.mock_add_claim.assert_called_once()
-        self.assertEquals(self.mock_add_qualifier.call_count, 2)
+        self.assertEqual(self.mock_add_qualifier.call_count, 2)
         self.mock_add_reference.assert_called_once()
 
     def test_add_new_claim_old_property_old_value_with_same_quals(self):
@@ -664,9 +664,9 @@ class TestAddNewClaim(BaseTest):
         self.wd_stuff.addNewClaim(self.prop, statement, self.wd_page, self.ref)
 
         self.mock_add_claim.assert_not_called()
-        self.assertEquals(self.mock_add_qualifier.call_count, 2)
+        self.assertEqual(self.mock_add_qualifier.call_count, 2)
         self.mock_add_reference.assert_called_once()
-        self.assertEquals(
+        self.assertEqual(
             self.mock_add_reference.call_args[0][1].toJSON()['id'],
             expected_claim)
 
@@ -682,7 +682,7 @@ class TestAddNewClaim(BaseTest):
         self.mock_add_claim.assert_not_called()
         self.mock_add_claim.mock_add_qualifier()
         self.mock_add_reference.assert_called_once()
-        self.assertEquals(
+        self.assertEqual(
             self.mock_add_reference.call_args[0][1].toJSON()['id'],
             expected_claim)
 
@@ -698,7 +698,7 @@ class TestAddNewClaim(BaseTest):
         self.mock_add_claim.assert_not_called()
         self.mock_add_claim.mock_add_qualifier()
         self.mock_add_reference.assert_called_once()
-        self.assertEquals(
+        self.assertEqual(
             self.mock_add_reference.call_args[0][1].toJSON()['id'],
             expected_claim)
 
@@ -718,7 +718,7 @@ class TestAddNewClaim(BaseTest):
         with self.assertRaises(pywikibot.Error) as e:
             self.wd_stuff.addNewClaim(
                 self.prop, statement, self.wd_page, 'Not a ref')
-        self.assertEquals(str(e.exception),
+        self.assertEqual(str(e.exception),
                           'The provided reference was not a '
                           'Reference object. Crashing')
 
@@ -729,7 +729,7 @@ class TestAddNewClaim(BaseTest):
         with self.assertRaises(pywikibot.Error) as e:
             self.wd_stuff.addNewClaim(
                 self.prop, statement, self.wd_page, self.ref)
-        self.assertEquals(str(e.exception),
+        self.assertEqual(str(e.exception),
                           'Problem adding P84 claim to [[wikidata:test:-1]]: '
                           'Multiple identical claims')
 
@@ -772,14 +772,14 @@ class TestMatchClaim(BaseTest):
         with self.assertRaises(pywikibot.Error) as e:
             self.wd_stuff.match_claim(
                 self.claims, self.qualifiers, self.force)
-        self.assertEquals(str(e.exception), 'Multiple identical claims')
+        self.assertEqual(str(e.exception), 'Multiple identical claims')
 
     def test_match_claim_empty_qualifier_exact(self):
         # 2. if no qualifier select the unqualified
         self.claims.append(self.one_qual_no_ref)
         self.claims.append(self.no_qual_no_ref)
         expected_claim = self.no_qual_no_ref
-        self.assertEquals(
+        self.assertEqual(
             self.wd_stuff.match_claim(
                 self.claims, self.qualifiers, self.force),
             expected_claim)
@@ -791,7 +791,7 @@ class TestMatchClaim(BaseTest):
         self.claims.append(self.two_qual_no_ref)
         self.qualifiers.append(self.matched_qualifier)
         expected_claim = self.one_qual_no_ref
-        self.assertEquals(
+        self.assertEqual(
             self.wd_stuff.match_claim(
                 self.claims, self.qualifiers, self.force),
             expected_claim)
@@ -803,7 +803,7 @@ class TestMatchClaim(BaseTest):
         with self.assertRaises(pywikibot.Error) as e:
             self.wd_stuff.match_claim(
                 self.claims, self.qualifiers, self.force)
-        self.assertEquals(str(e.exception), 'Multiple semi-identical claims')
+        self.assertEqual(str(e.exception), 'Multiple semi-identical claims')
 
     def test_match_claim_one_qualifier_close(self):
         # 4. if qualified select the closest match
@@ -812,7 +812,7 @@ class TestMatchClaim(BaseTest):
         self.claims.append(self.two_qual_no_ref)
         self.qualifiers.append(self.matched_qualifier)
         expected_claim = self.two_qual_no_ref
-        self.assertEquals(
+        self.assertEqual(
             self.wd_stuff.match_claim(
                 self.claims, self.qualifiers, self.force),
             expected_claim)
@@ -832,7 +832,7 @@ class TestMatchClaim(BaseTest):
         self.claims.append(self.no_qual_no_ref)
         expected_claim = self.no_qual_no_ref
         self.qualifiers.append(self.unmatched_qualifier)
-        self.assertEquals(
+        self.assertEqual(
             self.wd_stuff.match_claim(
                 self.claims, self.qualifiers, self.force),
             expected_claim)
@@ -844,7 +844,7 @@ class TestMatchClaim(BaseTest):
         self.qualifiers.append(self.unmatched_qualifier)
         self.force = True
         expected_claim = self.no_qual_two_ref
-        self.assertEquals(
+        self.assertEqual(
             self.wd_stuff.match_claim(
                 self.claims, self.qualifiers, self.force),
             expected_claim)

--- a/tests/test_WikidataStuff.py
+++ b/tests/test_WikidataStuff.py
@@ -238,40 +238,62 @@ class TestHasQualifier(BaseTest):
 
     """Test hasQualifier()."""
 
+    def setUp(self):
+        super(TestHasQualifier, self).setUp()
+        self.claim_no_qual = self.wd_page.claims['P174'][2]
+        # one qualifier: P174:A qualifier
+        self.claim_one_qual = self.wd_page.claims['P174'][0]
+        # two qualifiers: P174:A qualifier, P664:Another qualifier
+        self.claim_two_quals_diff_p = self.wd_page.claims['P174'][4]
+        # two qualifiers: P174:A qualifier, P174:Another qualifier
+        self.claim_two_quals_same_p = self.wd_page.claims['P174'][5]
+
+        # load three claims to use when making references
+        self.qual_1 = WD.WikidataStuff.Qualifier('P174', 'A qualifier')
+        self.qual_2 = WD.WikidataStuff.Qualifier('P664', 'Another qualifier')
+        self.qual_3 = WD.WikidataStuff.Qualifier('P174', 'Another qualifier')
+        self.unmatched_val = WD.WikidataStuff.Qualifier('P174', 'Unmatched')
+        self.unmatched_p = WD.WikidataStuff.Qualifier('P0', 'A qualifier')
+
     def test_has_qualifier_no_qualifier(self):
-        claim = self.wd_page.claims['P664'][0]
-        test_qual = WD.WikidataStuff.Qualifier('P174', 'qualifier')
-        self.assertFalse(self.wd_stuff.hasQualifier(test_qual, claim))
+        self.assertFalse(
+            self.wd_stuff.hasQualifier(
+                self.qual_1, self.claim_no_qual))
+
+    def test_has_qualifier_different_qualifier(self):
+        self.assertFalse(
+            self.wd_stuff.hasQualifier(
+                self.qual_2, self.claim_one_qual))
 
     def test_has_qualifier_different_qualifier_prop(self):
-        claim = self.wd_page.claims['P664'][1]
-        test_qual = WD.WikidataStuff.Qualifier('P0', 'qualifier')
-        self.assertFalse(self.wd_stuff.hasQualifier(test_qual, claim))
+        self.assertFalse(
+            self.wd_stuff.hasQualifier(
+                self.unmatched_p, self.claim_one_qual))
 
     def test_has_qualifier_different_qualifier_value(self):
-        claim = self.wd_page.claims['P664'][1]
-        test_qual = WD.WikidataStuff.Qualifier('P174', 'Another qualifier')
-        self.assertFalse(self.wd_stuff.hasQualifier(test_qual, claim))
+        self.assertFalse(
+            self.wd_stuff.hasQualifier(
+                self.unmatched_val, self.claim_one_qual))
 
     def test_has_qualifier_same_qualifier(self):
-        claim = self.wd_page.claims['P664'][1]
-        test_qual = WD.WikidataStuff.Qualifier('P174', 'qualifier')
-        self.assertTrue(self.wd_stuff.hasQualifier(test_qual, claim))
+        self.assertTrue(
+            self.wd_stuff.hasQualifier(
+                self.qual_1, self.claim_one_qual))
 
     def test_has_qualifier_multiple_qualifiers_different_prop(self):
-        claim = self.wd_page.claims['P174'][4]
-        expect_qual_1 = WD.WikidataStuff.Qualifier('P174', 'A qualifier')
-        expect_qual_2 = WD.WikidataStuff.Qualifier('P664', 'Another qualifier')
-        unexpected_qual = WD.WikidataStuff.Qualifier('P174', 'Not a qualifier')
+        claim = self.claim_two_quals_diff_p
+        expect_qual_1 = self.qual_1
+        expect_qual_2 = self.qual_2
+        unexpected_qual = self.unmatched_val
         self.assertTrue(self.wd_stuff.hasQualifier(expect_qual_1, claim))
         self.assertTrue(self.wd_stuff.hasQualifier(expect_qual_2, claim))
         self.assertFalse(self.wd_stuff.hasQualifier(unexpected_qual, claim))
 
     def test_has_qualifier_multiple_qualifiers_same_prop(self):
-        claim = self.wd_page.claims['P174'][5]
-        expect_qual_1 = WD.WikidataStuff.Qualifier('P174', 'A qualifier')
-        expect_qual_2 = WD.WikidataStuff.Qualifier('P174', 'Another qualifier')
-        unexpected_qual = WD.WikidataStuff.Qualifier('P174', 'Not a qualifier')
+        claim = self.claim_two_quals_same_p
+        expect_qual_1 = self.qual_1
+        expect_qual_2 = self.qual_3
+        unexpected_qual = self.unmatched_val
         self.assertTrue(self.wd_stuff.hasQualifier(expect_qual_1, claim))
         self.assertTrue(self.wd_stuff.hasQualifier(expect_qual_2, claim))
         self.assertFalse(self.wd_stuff.hasQualifier(unexpected_qual, claim))
@@ -283,45 +305,47 @@ class TestHasAllQualifiers(BaseTest):
 
     def setUp(self):
         super(TestHasAllQualifiers, self).setUp()
-        self.claim = self.wd_page.claims['P174'][4]  # 2 quals
         self.quals = []
+
+        # load claims
+        self.claim_no_qual = self.wd_page.claims['P174'][2]
+        # two qualifiers: P174:A qualifier, P664:Another qualifier
+        self.claim = self.wd_page.claims['P174'][4]
+
+        # load qualifiers
+        self.qual_1 = WD.WikidataStuff.Qualifier('P174', 'A qualifier')
+        self.qual_2 = WD.WikidataStuff.Qualifier('P664', 'Another qualifier')
+        self.unmatched = WD.WikidataStuff.Qualifier('P174', 'Unmatched')
 
     def test_has_all_qualifiers_none(self):
         with self.assertRaises(TypeError):
             self.wd_stuff.has_all_qualifiers(None, self.claim)
 
     def test_has_all_qualifiers_empty(self):
-        self.claim = self.wd_page.claims['P174'][2]  # no quals
         expected = (True, True)
         self.assertEquals(
-            self.wd_stuff.has_all_qualifiers(self.quals, self.claim),
+            self.wd_stuff.has_all_qualifiers(self.quals, self.claim_no_qual),
             expected)
 
     def test_has_all_qualifiers_has_all(self):
-        self.quals.append(
-            WD.WikidataStuff.Qualifier('P174', 'A qualifier'))
-        self.quals.append(
-            WD.WikidataStuff.Qualifier('P664', 'Another qualifier'))
+        self.quals.append(self.qual_1)
+        self.quals.append(self.qual_2)
         expected = (True, True)
         self.assertEquals(
             self.wd_stuff.has_all_qualifiers(self.quals, self.claim),
             expected)
 
     def test_has_all_qualifiers_has_all_but_one(self):
-        self.quals.append(
-            WD.WikidataStuff.Qualifier('P174', 'A qualifier'))
-        self.quals.append(
-            WD.WikidataStuff.Qualifier('P664', 'Another qualifier'))
-        self.quals.append(
-            WD.WikidataStuff.Qualifier('P174', 'Not a qualifier'))
+        self.quals.append(self.qual_1)
+        self.quals.append(self.qual_2)
+        self.quals.append(self.unmatched)
         expected = (False, False)
         self.assertEquals(
             self.wd_stuff.has_all_qualifiers(self.quals, self.claim),
             expected)
 
     def test_has_all_qualifiers_has_all_plus_one(self):
-        self.quals.append(
-            WD.WikidataStuff.Qualifier('P174', 'A qualifier'))
+        self.quals.append(self.qual_1)
         expected = (False, True)
         self.assertEquals(
             self.wd_stuff.has_all_qualifiers(self.quals, self.claim),
@@ -550,10 +574,8 @@ class TestAddNewClaim(BaseTest):
         self.ref = None
         self.prop = 'P509'  # an unused property of type string
         self.value = 'A statement'
-        self.quals = [
-            WD.WikidataStuff.Qualifier('P174', 'A qualifier'),
-            WD.WikidataStuff.Qualifier('P664', 'Another qualifier')
-        ]
+        self.qual_1 = WD.WikidataStuff.Qualifier('P174', 'A qualifier')
+        self.qual_2 = WD.WikidataStuff.Qualifier('P664', 'Another qualifier')
 
     def test_add_new_claim_new_property(self):
         statement = WD.WikidataStuff.Statement(self.value)
@@ -590,7 +612,7 @@ class TestAddNewClaim(BaseTest):
 
     def test_add_new_claim_new_property_with_quals(self):
         statement = WD.WikidataStuff.Statement(self.value)
-        statement.addQualifier(self.quals[0]).addQualifier(self.quals[1])
+        statement.addQualifier(self.qual_1).addQualifier(self.qual_2)
         self.wd_stuff.addNewClaim(self.prop, statement, self.wd_page, self.ref)
 
         self.mock_add_claim.assert_called_once()
@@ -600,7 +622,7 @@ class TestAddNewClaim(BaseTest):
     def test_add_new_claim_old_property_new_value_with_quals(self):
         self.prop = 'P174'
         statement = WD.WikidataStuff.Statement(self.value)
-        statement.addQualifier(self.quals[0]).addQualifier(self.quals[1])
+        statement.addQualifier(self.qual_1).addQualifier(self.qual_2)
         self.wd_stuff.addNewClaim(self.prop, statement, self.wd_page, self.ref)
 
         self.mock_add_claim.assert_called_once()
@@ -611,7 +633,7 @@ class TestAddNewClaim(BaseTest):
         self.prop = 'P174'
         self.value = 'A string'
         statement = WD.WikidataStuff.Statement(self.value)
-        statement.addQualifier(self.quals[0]).addQualifier(self.quals[1])
+        statement.addQualifier(self.qual_1).addQualifier(self.qual_2)
         expected_claim = 'Q27399$3f62d521-4efe-e8de-8f2d-0d8a10e024cf'
         self.wd_stuff.addNewClaim(self.prop, statement, self.wd_page, self.ref)
 
@@ -626,7 +648,7 @@ class TestAddNewClaim(BaseTest):
         self.prop = 'P174'
         self.value = 'A string entry with a qualifier'
         statement = WD.WikidataStuff.Statement(self.value)
-        statement.addQualifier(self.quals[0]).addQualifier(self.quals[1])
+        statement.addQualifier(self.qual_1).addQualifier(self.qual_2)
         self.wd_stuff.addNewClaim(self.prop, statement, self.wd_page, self.ref)
 
         self.mock_add_claim.assert_called_once()
@@ -637,7 +659,7 @@ class TestAddNewClaim(BaseTest):
         self.prop = 'P174'
         self.value = 'A string entry with many qualifiers'
         statement = WD.WikidataStuff.Statement(self.value)
-        statement.addQualifier(self.quals[0]).addQualifier(self.quals[1])
+        statement.addQualifier(self.qual_1).addQualifier(self.qual_2)
         expected_claim = 'Q27399$b48a2630-4fbb-932d-4f01-eefcf1e73f59'
         self.wd_stuff.addNewClaim(self.prop, statement, self.wd_page, self.ref)
 

--- a/tests/test_WikidataStuff.py
+++ b/tests/test_WikidataStuff.py
@@ -496,17 +496,23 @@ class TestAddNewClaim(BaseTest):
 
     def test_add_new_claim_raise_error_on_bad_ref(self):
         statement = WD.WikidataStuff.Statement(self.value)
-        with self.assertRaises(pywikibot.Error):
+        with self.assertRaises(pywikibot.Error) as e:
             self.wd_stuff.addNewClaim(
                 self.prop, statement, self.wd_page, 'Not a ref')
+        self.assertEquals(str(e.exception),
+                          'The provided reference was not a '
+                          'Reference object. Crashing')
 
     def test_add_new_claim_reraise_error_on_duplicate_matching_claim(self):
         self.prop = 'P84'
         self.value = pywikibot.ItemPage(self.repo, 'Q505')
         statement = WD.WikidataStuff.Statement(self.value)
-        with self.assertRaises(pywikibot.Error):
+        with self.assertRaises(pywikibot.Error) as e:
             self.wd_stuff.addNewClaim(
                 self.prop, statement, self.wd_page, self.ref)
+        self.assertEquals(str(e.exception),
+                          'Problem adding P84 claim to [[wikidata:test:-1]]: '
+                          'Multiple identical claims')
 
 
 class TestMatchClaim(BaseTest):
@@ -544,9 +550,10 @@ class TestMatchClaim(BaseTest):
         # 1. many exact matches: raise error (means duplicates on Wikidata)
         self.claims.append(self.no_qual_two_ref)
         self.claims.append(self.no_qual_no_ref)
-        with self.assertRaises(pywikibot.Error):
+        with self.assertRaises(pywikibot.Error) as e:
             self.wd_stuff.match_claim(
                 self.claims, self.qualifiers, self.force)
+        self.assertEquals(str(e.exception), 'Multiple identical claims')
 
     def test_match_claim_empty_qualifier_exact(self):
         # 2. if no qualifier select the unqualified
@@ -574,9 +581,10 @@ class TestMatchClaim(BaseTest):
         # 3. unclaimed i equally close to any with claims
         self.claims.append(self.one_qual_no_ref)
         self.claims.append(self.two_qual_no_ref)
-        with self.assertRaises(pywikibot.Error):
+        with self.assertRaises(pywikibot.Error) as e:
             self.wd_stuff.match_claim(
                 self.claims, self.qualifiers, self.force)
+        self.assertEquals(str(e.exception), 'Multiple semi-identical claims')
 
     def test_match_claim_one_qualifier_close(self):
         # 4. if qualified select the closest match

--- a/tests/test_WikidataStuff.py
+++ b/tests/test_WikidataStuff.py
@@ -449,6 +449,82 @@ class TestAddReference(BaseTest):
             [self.ref_2], summary=None)
 
 
+class TestAddQualifier(BaseTest):
+
+    """Test addQualifier()."""
+
+    def setUp(self):
+        super(TestAddQualifier, self).setUp()
+        self.claim = self.wd_page.claims['P174'][2]
+        self.qual = WD.WikidataStuff.Qualifier('P174', 'A qualifier')
+
+        qualifier_patcher = mock.patch(
+            'wikidataStuff.WikidataStuff.pywikibot.Claim.addQualifier')
+        make_claim_patcher = mock.patch(
+            'wikidataStuff.WikidataStuff.WikidataStuff.make_simple_claim')
+        has_qualifier_patcher = mock.patch(
+            'wikidataStuff.WikidataStuff.WikidataStuff.hasQualifier')
+        self.mock_add_qualifier = qualifier_patcher.start()
+        self.mock_make_simple_claim = make_claim_patcher.start()
+        self.mock_has_qualifier = has_qualifier_patcher.start()
+        self.addCleanup(qualifier_patcher.stop)
+        self.addCleanup(make_claim_patcher.stop)
+        self.addCleanup(has_qualifier_patcher.stop)
+
+    def test_add_qualifier_empty_qual(self):
+        with self.assertRaises(pywikibot.Error) as e:
+            self.wd_stuff.addQualifier(item=None, claim=None, qual=None)
+        self.assertEquals(
+            str(e.exception),
+            'Cannot call addQualifier() without a qualifier.')
+        self.mock_has_qualifier.assert_not_called()
+        self.mock_make_simple_claim.assert_not_called()
+        self.mock_add_qualifier.assert_not_called()
+
+    def test_add_qualifier_has(self):
+        self.mock_has_qualifier.return_value = True
+        self.assertFalse(
+            self.wd_stuff.addQualifier(
+                item=self.wd_page,
+                claim=self.claim,
+                qual=self.qual))
+        self.mock_has_qualifier.assert_called_once_with(
+            self.qual, self.claim)
+        self.mock_make_simple_claim.assert_not_called()
+        self.mock_add_qualifier.assert_not_called()
+
+    def test_add_qualifier_has_not(self):
+        self.mock_has_qualifier.return_value = False
+        self.mock_make_simple_claim.return_value = 'test'
+        self.assertTrue(
+            self.wd_stuff.addQualifier(
+                item=self.wd_page,
+                claim=self.claim,
+                qual=self.qual))
+        self.mock_has_qualifier.assert_called_once_with(
+            self.qual, self.claim)
+        self.mock_make_simple_claim.assert_called_once_with(
+            self.qual.prop, self.qual.itis)
+        self.mock_add_qualifier.assert_called_once_with(
+            'test', summary=None)
+
+    def test_add_qualifier_with_summary(self):
+        self.mock_has_qualifier.return_value = False
+        self.mock_make_simple_claim.return_value = 'test'
+        self.assertTrue(
+            self.wd_stuff.addQualifier(
+                item=self.wd_page,
+                claim=self.claim,
+                qual=self.qual,
+                summary='test_me'))
+        self.mock_has_qualifier.assert_called_once_with(
+            self.qual, self.claim)
+        self.mock_make_simple_claim.assert_called_once_with(
+            self.qual.prop, self.qual.itis)
+        self.mock_add_qualifier.assert_called_once_with(
+            'test', summary='test_me')
+
+
 class TestAddNewClaim(BaseTest):
 
     """Test addNewClaim()."""

--- a/tests/test_WikidataStuff.py
+++ b/tests/test_WikidataStuff.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8  -*-
 """Unit tests for WikidataStuff."""
+from __future__ import unicode_literals
 import json
 import mock
 import os

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -85,31 +85,31 @@ class TestSigFigError(unittest.TestCase):
     """Test sig_fig_error()."""
 
     def test_sig_fig_error_zero(self):
-        self.assertEquals(sig_fig_error("0"), 0.5)
+        self.assertEqual(sig_fig_error("0"), 0.5)
 
     def test_sig_fig_error_one(self):
-        self.assertEquals(sig_fig_error("1"), 0.5)
+        self.assertEqual(sig_fig_error("1"), 0.5)
 
     def test_sig_fig_error_big_int(self):
-        self.assertEquals(sig_fig_error("200"), 50.0)
+        self.assertEqual(sig_fig_error("200"), 50.0)
 
     def test_sig_fig_error_exact_int(self):
-        self.assertEquals(sig_fig_error("1010"), 5.0)
+        self.assertEqual(sig_fig_error("1010"), 5.0)
 
     def test_sig_fig_error_negative_int(self):
-        self.assertEquals(sig_fig_error("-220"), 5.0)
+        self.assertEqual(sig_fig_error("-220"), 5.0)
 
     def test_sig_fig_error_zero_padded_int(self):
-        self.assertEquals(sig_fig_error("03300"), 50.0)
+        self.assertEqual(sig_fig_error("03300"), 50.0)
 
     def test_sig_fig_error_decimal_zero(self):
-        self.assertEquals(sig_fig_error("0.0"), 0.05)
+        self.assertEqual(sig_fig_error("0.0"), 0.05)
 
     def test_sig_fig_error_with_decimal(self):
-        self.assertEquals(sig_fig_error("11.0"), 0.05)
+        self.assertEqual(sig_fig_error("11.0"), 0.05)
 
     def test_sig_fig_error_with_only_decimal(self):
-        self.assertEquals(sig_fig_error("0.1"), 0.05)
+        self.assertEqual(sig_fig_error("0.1"), 0.05)
 
     def test_sig_fig_error_negative_with_decimal(self):
-        self.assertEquals(sig_fig_error("-0.1234"), 0.00005)
+        self.assertEqual(sig_fig_error("-0.1234"), 0.00005)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8  -*-
 """Unit tests for converters."""
+from __future__ import unicode_literals
 
 import unittest
 from wikidataStuff.helpers import (

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,pydocstyle,py27
+envlist = flake8,pydocstyle,py27,py3
 skipsdist=true
 
 [testenv]

--- a/wikidataStuff/WikidataStringSearch.py
+++ b/wikidataStuff/WikidataStringSearch.py
@@ -190,9 +190,9 @@ class WikidataStringSearch(object):
 
     def _print(self, s):
         """
-        Print text if verbose.
+        Output text if verbose.
 
-        @param s: text to print
+        @param s: text to output
         @type s: basestring
         """
         if self.verbose:

--- a/wikidataStuff/WikidataStringSearch.py
+++ b/wikidataStuff/WikidataStringSearch.py
@@ -4,11 +4,11 @@
 Must be run from labs and does these (SQL LIKE style) in
 labels, aliases and descriptions of items.
 """
-from __future__ import print_function
 from __future__ import unicode_literals
 from builtins import object
 import MySQLdb
 
+from pywikibot import output
 import wikidataStuff.helpers as helpers
 
 
@@ -196,7 +196,7 @@ class WikidataStringSearch(object):
         @type s: basestring
         """
         if self.verbose:
-            print(s)
+            output(s)
 
     @staticmethod
     def _type_fixed_row(row):

--- a/wikidataStuff/WikidataStringSearch.py
+++ b/wikidataStuff/WikidataStringSearch.py
@@ -36,14 +36,14 @@ class WikidataStringSearch(object):
 
         # get types
         self.cursor.execute("SELECT DISTINCT term_type FROM wb_terms;")
-        for t in self.cursor.fetchall():
-            self.term_types += t
+        for row in self.cursor.fetchall():
+            self.term_types += WikidataStringSearch._type_fixed_row(row)
         self._print('found %d term_types' % len(self.term_types))
 
         # get languages
         self.cursor.execute("SELECT DISTINCT term_language FROM wb_terms;")
-        for l in self.cursor.fetchall():
-            self.languages += l
+        for row in self.cursor.fetchall():
+            self.languages += WikidataStringSearch._type_fixed_row(row)
         self._print('found %d languages' % len(self.languages))
 
     def close_connection(self):
@@ -197,6 +197,11 @@ class WikidataStringSearch(object):
         """
         if self.verbose:
             print(s)
+
+    @staticmethod
+    def _type_fixed_row(row):
+        """Ensure byte strings are converted to str, unicode as appropriate."""
+        return tuple([el.decode('utf-8') if isinstance(el, bytes) else el for el in row])
 
     @staticmethod
     def sql_in_format(l):

--- a/wikidataStuff/WikidataStringSearch.py
+++ b/wikidataStuff/WikidataStringSearch.py
@@ -4,6 +4,7 @@
 Must be run from labs and does these (SQL LIKE style) in
 labels, aliases and descriptions of items.
 """
+from __future__ import print_function
 import MySQLdb
 
 
@@ -191,7 +192,7 @@ class WikidataStringSearch:
         @type s: basestring
         """
         if self.verbose:
-            print s
+            print(s)
 
     @staticmethod
     def sql_in_format(l):

--- a/wikidataStuff/WikidataStringSearch.py
+++ b/wikidataStuff/WikidataStringSearch.py
@@ -5,10 +5,14 @@ Must be run from labs and does these (SQL LIKE style) in
 labels, aliases and descriptions of items.
 """
 from __future__ import print_function
+from __future__ import unicode_literals
+from builtins import object
 import MySQLdb
 
+import wikidataStuff.helpers as helpers
 
-class WikidataStringSearch:
+
+class WikidataStringSearch(object):
     """Run string searches on Wikidata from labs."""
 
     def __init__(self, verbose=False):
@@ -85,7 +89,7 @@ class WikidataStringSearch:
 
             # Check each is correctly formatted
             if not all(e.startswith('Q') and
-                       isinstance(e, basestring) and
+                       helpers.is_str(e) and
                        WikidataStringSearch.is_int(e[1:])
                        for e in entities):
                 self._print('Each entity must be a string like Q<integer>')

--- a/wikidataStuff/WikidataStringSearch.py
+++ b/wikidataStuff/WikidataStringSearch.py
@@ -50,14 +50,14 @@ class WikidataStringSearch:
         Test that the user input is valid.
 
         @param text: the text to search for
-        @type text: str, unicode
+        @type text: basestring
         @param language: the language to search in, defaults to None=any
-        @type language: str, unicode, or None
+        @type language: basestring or None
         @param entities: the language to search in, defaults to None=any
-        @type entities: list (of str, unicode), or None
+        @type entities: list (of basestring), or None
         @param term_type: field to search in, defaults
             to None=['label', 'alias']
-        @type term_type: str, unicode, or None
+        @type term_type: basestring or None
         @return: if input is valid
         @rtype: bool
         """
@@ -84,7 +84,7 @@ class WikidataStringSearch:
 
             # Check each is correctly formatted
             if not all(e.startswith('Q') and
-                       isinstance(e, (str, unicode)) and
+                       isinstance(e, basestring) and
                        WikidataStringSearch.is_int(e[1:])
                        for e in entities):
                 self._print('Each entity must be a string like Q<integer>')
@@ -125,14 +125,14 @@ class WikidataStringSearch:
         to within a list of entities.
 
         @param text: the text to search for
-        @type text: str, unicode
+        @type text: basestring
         @param language: the language to search in, defaults to None=any
-        @type language: str, unicode, or None
+        @type language: basestring or None
         @param entities: the language to search in, defaults to None=any
-        @type entities: list (of str, unicode), or None
+        @type entities: list (of basestring), or None
         @param term_type: field to search in, defaults
             to None=['label', 'alias']
-        @type term_type: str, unicode, or None
+        @type term_type: basestring or None
         @return: list of matching Q values
         @rtype: list (of str)
         """
@@ -188,7 +188,7 @@ class WikidataStringSearch:
         Print text if verbose.
 
         @param s: text to print
-        @type s: string or unicode
+        @type s: basestring
         """
         if self.verbose:
             print s

--- a/wikidataStuff/WikidataStuff.py
+++ b/wikidataStuff/WikidataStuff.py
@@ -13,8 +13,6 @@ import pywikibot
 import pywikibot.data.wikidataquery as wdquery  # Needed for wdqLookup
 from pywikibot.tools import deprecated
 
-from wikidataStuff.WikidataStringSearch import WikidataStringSearch
-
 
 class WikidataStuff(object):
     """Useful methods for interacting with Wikidata using pywikibot."""
@@ -182,6 +180,7 @@ class WikidataStuff(object):
             os.path.expanduser("~") +
             "/replica.my.cnf")
         if self.onLabs:
+            from wikidataStuff.WikidataStringSearch import WikidataStringSearch
             self.wdss = WikidataStringSearch()
 
         # extend pywikibot.Claim with a __repr__ method

--- a/wikidataStuff/WikidataStuff.py
+++ b/wikidataStuff/WikidataStuff.py
@@ -367,6 +367,9 @@ class WikidataStuff(object):
         @param qual: Qualifier to check
         @param summary: summary to append to auto-generated edit summary
         """
+        if not qual:
+            raise pywikibot.Error(
+                'Cannot call addQualifier() without a qualifier.')
         # check if already present
         if self.hasQualifier(qual, claim):
             return False

--- a/wikidataStuff/WikidataStuff.py
+++ b/wikidataStuff/WikidataStuff.py
@@ -277,6 +277,9 @@ class WikidataStuff(object):
         """
         Add a reference if not already present.
 
+        If a source contains the claims in WD.Reference AND additional claims,
+        it will not be sourced.
+
         @param item: the item on which all of this happens
         @param claim: the pywikibot.Claim to be sourced
         @param ref: the WD.Reference to add

--- a/wikidataStuff/WikidataStuff.py
+++ b/wikidataStuff/WikidataStuff.py
@@ -481,8 +481,9 @@ class WikidataStuff(object):
             matching_claim = self.match_claim(
                 prior_claims, statement.quals, statement.force)
         except pywikibot.Error as e:
-            raise pywikibot.Error(
+            pywikibot.warning(
                 "Problem adding %s claim to %s: %s" % (prop, item, e))
+            return
 
         if matching_claim:
             for qual in statement.quals:

--- a/wikidataStuff/WikidataStuff.py
+++ b/wikidataStuff/WikidataStuff.py
@@ -5,6 +5,8 @@
 # License: MIT
 #
 """Generally useful methods for interacting with Wikidata using pywikibot."""
+from __future__ import unicode_literals
+from builtins import dict, str, object
 import os.path  # Needed for WikidataStringSearch
 
 import pywikibot
@@ -230,7 +232,7 @@ class WikidataStuff(object):
             edit_summary = u'%s, %s' % (edit_summary, summary)
 
         # look at label
-        if not item.labels or lang not in item.labels.keys():
+        if not item.labels or lang not in item.labels:
             # add name to label
             labels = {lang: name}
             edit_summary %= 'label'
@@ -242,7 +244,7 @@ class WikidataStuff(object):
                 if name.lower() == item.labels[lang].lower():
                     return None
             edit_summary %= 'alias'
-            if not item.aliases or lang not in item.aliases.keys():
+            if not item.aliases or lang not in item.aliases:
                 aliases = {lang: [name, ]}
                 item.editAliases(aliases, summary=edit_summary)
                 pywikibot.output(edit_summary)
@@ -266,7 +268,7 @@ class WikidataStuff(object):
         """
         if claim.sources:
             for i, source in enumerate(claim.sources):
-                if prop in source.keys():
+                if prop in source:
                     for s in source[prop]:
                         if self.bypassRedirect(s.getTarget()) == itis:
                             return True
@@ -343,7 +345,7 @@ class WikidataStuff(object):
         @type claim: pywikibot.Claim
         """
         if claim.qualifiers:
-            if qual.prop in claim.qualifiers.keys():
+            if qual.prop in claim.qualifiers:
                 for s in claim.qualifiers[qual.prop]:
                     if self.bypassRedirect(s.getTarget()) == qual.itis:
                         return True
@@ -402,7 +404,7 @@ class WikidataStuff(object):
         @rtype: list of pywikibot.Claim
         """
         hits = []
-        if prop in item.claims.keys():
+        if prop in item.claims:
             for claim in item.claims[prop]:
                 if isinstance(itis, pywikibot.WbTime):
                     # WbTime compared differently
@@ -428,7 +430,7 @@ class WikidataStuff(object):
         @rtype: list of pywikibot.Claim
         """
         hits = []
-        if prop in item.claims.keys():
+        if prop in item.claims:
             for claim in item.claims[prop]:
                 if claim.getSnakType() == snaktype:
                     hits.append(claim)
@@ -650,7 +652,7 @@ class WikidataStuff(object):
         @type summary: basestring
         @rtype: pywikibot.ItemPage
         """
-        identification = {}  # If empty this defaults to creating an entity
+        identification = dict()  # If empty this defaults to creating an entity
         result = self.repo.editEntity(identification, data, summary=summary)
         pywikibot.output(summary)  # afterwards in case an error is raised
 

--- a/wikidataStuff/helpers.py
+++ b/wikidataStuff/helpers.py
@@ -34,9 +34,11 @@ try:
     basestring  # attempt to evaluate basestring
 except NameError:
     def is_str(s):
+        """Python 3 test for string type."""
         return isinstance(s, str)
 else:
     def is_str(s):
+        """Python 2 test for basestring type."""
         return isinstance(s, basestring)
 
 

--- a/wikidataStuff/helpers.py
+++ b/wikidataStuff/helpers.py
@@ -8,10 +8,9 @@ Methods commonly shared by Wikidata-stuff bots which are:
   WikidataStuff.py then it is defined there and a wrapper provided here.
 """
 from __future__ import unicode_literals
-from builtins import dict, str
+from builtins import dict, open, str
 import os
 import json
-import codecs
 import requests  # for dbpedia_2_wikidata
 import time  # for dbpedia_2_wikidata
 from datetime import datetime  # for today_as_WbTime
@@ -60,7 +59,7 @@ def load_json_file(filename, force_path=None):
     if force_path:
         path = os.path.dirname(os.path.abspath(force_path))
         filename = os.path.join(path, filename)
-    with codecs.open(filename, 'r', 'utf-8') as f:
+    with open(filename, 'r', encoding='utf-8') as f:
         return json.load(f)
 
 

--- a/wikidataStuff/helpers.py
+++ b/wikidataStuff/helpers.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Common non-fundamental methods used by WikidataStuff bots.
 
-Methods comonly shared by Wikidata-stuff bots which are:
+Methods commonly shared by Wikidata-stuff bots which are:
 * not fundamental enough to be in WikidataStuff.py
 * not limited to kulturNav (in which case they are in kulturnavBot.py)
 * unrelated to Wikidata but reused throughout, if also needed in
@@ -38,7 +38,7 @@ def load_json_file(filename, force_path=None):
     another directory.
 
     @param filename: The filename, and path, to the json file
-    @type filename: str, unicode
+    @type filename: basestring
     @param force_path: Force the system to look for the file in the
         same directory as this file
     @type force_path: str
@@ -57,9 +57,9 @@ def fill_cache(pid, queryoverride=None, cache_max_age=0):
     Query Wikidata to fill the cache of entities which contain the id.
 
     @param pid: The id property
-    @type pid: str, unicode
+    @type pid: basestring
     @param queryoverride: A WDQ query to use instead of CLAIM[pid]
-    @type queryoverride: str, unicode
+    @type queryoverride: basestring
     @param cache_max_age: Max age of local cache, defaults to 0
     @type cache_max_age: int
     @return: Dictionary of IDno to Qno
@@ -115,7 +115,7 @@ def iso_to_WbTime(date):
     this returns the equivalent WbTime object
 
     @param item: An ISO date string
-    @type item: str, unicode
+    @type item: basestring
     @return: The converted result
     @rtype: pywikibot.WbTime
     """
@@ -156,9 +156,9 @@ def add_start_end_qualifiers(statement, startVal, endVal):
     @param statement: The statement to decorate
     @type statement: WD.Statement
     @param startVal: An ISO date string for the starting point
-    @type startVal: str, unicode, or None
+    @type startVal: basestring or None
     @param endVal: An ISO date string for the end point
-    @type endVal: str, unicode, or None
+    @type endVal: basestring or None
     @return: A statement decorated with start/end qualifiers
     @rtype: WD.Statement, or None
     """
@@ -193,9 +193,9 @@ def match_name(name, typ, wd, limit=75):
     stored in 'matchedNames' for later look-up.
 
     @param name: The name to search for
-    @type name: str, unicode
+    @type name: basestring
     @param typ: The name type (either 'lastName' or 'firstName')
-    @type typ: str, unicode
+    @type typ: basestring
     @param wd: The running WikidataStuff instance
     @type wd: WikidataStuff (WD)
     @param limit: Number of hits before skipping (defaults to 75,
@@ -244,9 +244,9 @@ def match_name_on_labs(name, types, wd):
     Requires that the bot is running on WMF toollabs.
 
     @param name: The name to search for
-    @type name: str, unicode
+    @type name: basestring
     @param types: The Q-values which are allowed for INSTANCE_OF_P
-    @type types: tuple of unicode
+    @type types: tuple of basestring
     @param wd: The running WikidataStuff instance
     @type wd: WikidataStuff (WD)
     @return: Any matching items
@@ -267,9 +267,9 @@ def match_name_off_labs(name, types, wd, limit):
     Less good than match_name_on_labs() but works from anywhere.
 
     @param name: The name to search for
-    @type name: str, unicode
+    @type name: basestring
     @param types: The Q-values which are allowed for INSTANCE_OF_P
-    @type types: tuple of unicode
+    @type types: tuple of basestring
     @param wd: The running WikidataStuff instance
     @type wd: WikidataStuff (WD)
     @return: Any matching items
@@ -305,7 +305,7 @@ def filter_on_types(obj, types, matches):
     @param obj: potential matches
     @type obj: pywikibot.ItemPage
     @param types: The Q-values which are allowed for INSTANCE_OF_P
-    @type types: tuple of unicode
+    @type types: tuple of basestring
     @param matches: list of confirmed matches
     @type matches: list (of pywikibot.ItemPage)
     """
@@ -371,8 +371,8 @@ def reorder_names(name):
     Strings with multiple commas result in an None being returned.
 
     @param name: The value to check
-    @type name: str, or unicode
-    @return str, or None
+    @type name: basestring
+    @return: str or None
     """
     if name.find(',') > 0 and len(name.split(',')) == 2:
         p = name.split(',')
@@ -392,12 +392,12 @@ def find_files(path, fileExts, subdir=True):
     Identify all files with a given extension in a given directory.
 
     @param path: Path to directory to look in
-    @type path: str, or unicode
+    @type path: basestring
     @param fileExts: Allowed file extensions (case insensitive)
-    @type fileExts: tuple (of str, or unicode)
+    @type fileExts: tuple (of basestring)
     @param subdir: Whether subdirs should also be searched, default=True
     @return: Paths to found files
-    @rtype: list (of str, or unicode)
+    @rtype: list (of basestring)
     """
     files = []
     subdirs = []
@@ -455,7 +455,7 @@ def dbpedia_2_wikidata(dbpedia):
         for g in json_data.get('@graph'):
             if g.get('http://www.w3.org/2002/07/owl#sameAs'):
                 for same in g.get('http://www.w3.org/2002/07/owl#sameAs'):
-                    if isinstance(same, (str, unicode)) and \
+                    if isinstance(same, basestring) and \
                             same.startswith('http://wikidata.org/entity/'):
                         return same[len('http://wikidata.org/entity/'):]
                 return None

--- a/wikidataStuff/wdqsLookup.py
+++ b/wikidataStuff/wdqsLookup.py
@@ -4,9 +4,14 @@
 Meant as a quick replacement for WDQ searches (which always time out) to be
 used until there is a proper pywikibot module.
 """
+from __future__ import unicode_literals
+from builtins import dict, str
 import json
 import requests
 import pywikibot
+
+import wikidataStuff.helpers as helpers
+
 
 BASE_URL = 'https://query.wikidata.org/bigdata/namespace/wdq/sparql?' \
            'format=json&query='
@@ -44,7 +49,7 @@ def make_simple_wdqs_query(query, verbose=False):
         data = []
         hooks = j['head']['vars']
         for binding in j['results']['bindings']:
-            entry = {}
+            entry = dict()
             for hook in hooks:
                 if binding.get(hook):
                     entry[hook] = binding[hook]['value']
@@ -117,15 +122,15 @@ def sanitize_wdqs_result(data):
     @return: sanitized data
     @rtype: list of str
     """
-    if isinstance(data, basestring):
+    if helpers.is_str(data):
         return data.split('/')[-1]
     elif isinstance(data, list):
         for i, d in enumerate(data):
             data[i] = d.split('/')[-1]
         return data
     if isinstance(data, dict):
-        new_data = {}
-        for k, v in data.iteritems():
+        new_data = dict()
+        for k, v in data.items():
             new_data[k.split('/')[-1]] = v
         return new_data
     else:
@@ -173,7 +178,7 @@ def list_of_dict_to_dict(data, key_key, value_key=None, allow_multiple=False):
     @return: the dict of new key-value pairs
     @rtype: dict
     """
-    results = {}
+    results = dict()
     for entry in data:
         key = entry[key_key]
         value = None
@@ -184,10 +189,10 @@ def list_of_dict_to_dict(data, key_key, value_key=None, allow_multiple=False):
             del value[key_key]
 
         if allow_multiple:
-            if key not in results.keys():
+            if key not in results:
                 results[key] = set()
             results[key].add(value)
-        elif key in results.keys() and value != results[key]:
+        elif key in results and value != results[key]:
             # two hits corresponding to different values
             raise pywikibot.Error(
                 'Double ids in Wikidata (%s): %s, %s' %

--- a/wikidataStuff/wdqsLookup.py
+++ b/wikidataStuff/wdqsLookup.py
@@ -117,7 +117,7 @@ def sanitize_wdqs_result(data):
     @return: sanitized data
     @rtype: list of str
     """
-    if isinstance(data, (str, unicode)):
+    if isinstance(data, basestring):
         return data.split('/')[-1]
     elif isinstance(data, list):
         for i, d in enumerate(data):


### PR DESCRIPTION
Make WikidataStuff py3 compatible

Requires changing MySQLdb library from MySQL-python to mysqlclient. Also requires some type fixing
to convert bytearrays to str/unicode.

Fixes #23